### PR TITLE
docs(nav): organize docs around runtime boundaries

### DIFF
--- a/index.md
+++ b/index.md
@@ -32,6 +32,7 @@ Backtrader compatibility is still important, but it is no longer the right top-l
 | See the runtime boundaries end to end | [Runtime Map](architecture/runtime_map.md) |
 | Compare backtest, paper, sandbox, and live behavior | [Mode Matrix](architecture/mode_matrix.md) |
 | Look up stable runtime vocabulary | [Runtime Terms](architecture/runtime_terms.md) |
+| Understand which docs are canonical vs transitional | [Docs Source of Truth and Migration Map](migration/docs_source_of_truth.md) |
 | Follow legacy links or older mental models safely | [Legacy Architecture Context](core_concepts/architecture.md) |
 | Install and run your first example | [Getting Started](getting_started/installation.md) |
 | Find stable user-facing APIs | [Reference](reference/entry_points.md) |

--- a/migration/docs_source_of_truth.md
+++ b/migration/docs_source_of_truth.md
@@ -1,0 +1,93 @@
+# Docs Source of Truth and Migration Map
+
+This page explains how to read the docs tree during the architecture reset.
+
+The point is not to pretend every older page disappeared. The point is to make it obvious which pages describe current truth, which pages describe transition, and which pages are retained as appendices or legacy context.
+
+## Reading Order
+
+If you want the current runtime story, read in this order:
+
+1. `architecture/`
+2. `testing/` and `development/testing_guidelines.md`
+3. `reference/`
+4. `migration/` and `compatibility/` only when you need transitional or older context
+
+## Source-of-Truth Categories
+
+| Category | What it means | Typical locations |
+| --- | --- | --- |
+| Current architecture truth | Preferred current runtime map and ownership boundaries | `architecture/` |
+| Runtime reliability truth | What the suite and runtime guarantees actually protect | `testing/`, `development/testing_guidelines.md` |
+| Stable user-facing reference | Entrypoints, configuration, and API surfaces users should rely on | `reference/` |
+| Migration guidance | Pages that explain how old and new models coexist during staged refactors | `migration/`, selected `compatibility/` pages |
+| Legacy context | Older mental models kept for historical links and compatibility reading | selected `core_concepts/`, `compatibility/` |
+| Appendices and planning material | deeper notes, RFCs, or internal plans that are informative but not primary truth | `plans/`, `internal/`, specialized reference pages |
+
+## What To Trust When Pages Disagree
+
+Use this precedence:
+
+1. `architecture/`
+2. `testing/` and current runtime guarantee pages
+3. `reference/`
+4. migration and compatibility pages
+5. older concept pages and planning docs
+
+If a page lower on that list contradicts one higher on the list, treat the higher page as canonical unless it explicitly says otherwise.
+
+## Why This Split Exists
+
+Cracktrader is in the middle of a staged architecture reset:
+
+- session-owned shared state
+- multi-strategy orchestration
+- execution contexts and routes
+- central inventory and risk
+- unified execution adapters
+- post-trade and control-plane hooks
+
+Older docs were written for a more Backtrader-centric mental model. Those pages are still useful, but they should not silently override the new runtime map.
+
+## Migration Buckets
+
+### Current Runtime Pages
+
+Use for:
+
+- architecture ingestion
+- current system ownership questions
+- runtime contracts and guarantees
+
+### Migration Pages
+
+Use for:
+
+- understanding renamed or reframed concepts
+- knowing why an older page still exists
+- staged rollout context while the tree is being reorganized
+
+### Legacy and Compatibility Pages
+
+Use for:
+
+- Backtrader compatibility
+- older feeds/brokers/store explanations
+- implementation detail that has not yet been rewritten into the new architecture map
+
+### Appendices
+
+Use for:
+
+- RFCs
+- planning notes
+- specialized operational or research references
+
+These pages can be valuable, but they are not the first place to look for current architecture truth.
+
+## Recommended Cross-Links
+
+- [Architecture Index](../architecture/agent_index.md)
+- [Runtime Map](../architecture/runtime_map.md)
+- [Runtime Guarantees](../testing/runtime_guarantees.md)
+- [Legacy Architecture Context](../core_concepts/architecture.md)

--- a/mkdocs-subtree.yml
+++ b/mkdocs-subtree.yml
@@ -66,30 +66,24 @@ nav:
   - Architecture:
       - Read This First: architecture/agent_index.md
       - Runtime Map: architecture/runtime_map.md
+      - Source of Truth and Migration Map: migration/docs_source_of_truth.md
       - Mode Matrix: architecture/mode_matrix.md
       - Runtime Terms: architecture/runtime_terms.md
-      - Legacy Architecture Context: core_concepts/architecture.md
-  - How-to:
-      - Configure the platform: getting_started/configuration.md
-      - Strategy cookbook: strategy_guide.md
-      - Use the Web API: reference/web_api.md
-  - Explanations:
-      - Schema-first boundary RFC: plans/schema_first_python_rust_boundary_rfc.md
+  - Runtime Boundaries:
       - Mode Divergence Ledger: mode_divergence_ledger.md
       - Strategies: core_concepts/strategies.md
       - Feeds: core_concepts/feeds.md
       - Brokers: core_concepts/brokers.md
       - Exchanges: core_concepts/exchanges.md
       - Caching model: core_concepts/caching.md
+  - How-to:
+      - Configure the platform: getting_started/configuration.md
+      - Strategy cookbook: strategy_guide.md
+      - Use the Web API: reference/web_api.md
   - Reference:
+      - Entry points and API freeze: reference/entry_points.md
       - API Reference: reference/web_api.md
       - Configuration reference: reference/configuration.md
-  - Performance:
-      - Overview: performance/overview.md
-      - Caching guide: performance/caching_guide.md
-      - Large datasets: performance/large_datasets.md
-      - Benchmarking: performance/benchmarking.md
-      - Optimization roadmap: performance/optimization_roadmap.md
   - Testing & Quality:
       - Runtime guarantees: testing/runtime_guarantees.md
       - Testing guidelines: development/testing_guidelines.md
@@ -100,6 +94,18 @@ nav:
       - Mocking policy: testing/mocking_policy.md
       - Backtrader compatibility envelope: testing/backtrader_compatibility_envelope.md
       - Rust CI policy: testing/rust_ci_policy.md
+  - Migration and Compatibility:
+      - Legacy architecture context: core_concepts/architecture.md
+      - Schema-first boundary RFC: plans/schema_first_python_rust_boundary_rfc.md
+      - Backtrader broker API envelope: compatibility/backtrader_broker_api_envelope.md
+  - Reference Appendices:
+      - Plugins and extras: plugins_and_extras.md
+  - Performance:
+      - Overview: performance/overview.md
+      - Caching guide: performance/caching_guide.md
+      - Large datasets: performance/large_datasets.md
+      - Benchmarking: performance/benchmarking.md
+      - Optimization roadmap: performance/optimization_roadmap.md
   - Contributing:
       - Overview: development/README.md
       - Workflow: development/workflow.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,47 +64,50 @@ nav:
   - Architecture:
       - Read This First: architecture/agent_index.md
       - Runtime Map: architecture/runtime_map.md
+      - Source of Truth and Migration Map: migration/docs_source_of_truth.md
       - Mode Matrix: architecture/mode_matrix.md
       - Runtime Terms: architecture/runtime_terms.md
-      - Legacy Architecture Context: core_concepts/architecture.md
-  - How-to:
-      - Web Hooks: webhooks.md
-      - Strategy Cookbook: strategy_guide.md
-  - Concepts:
-      - Schema-First Boundary RFC: plans/schema_first_python_rust_boundary_rfc.md
+  - Runtime Boundaries:
       - Mode Divergence Ledger: mode_divergence_ledger.md
       - Strategies: core_concepts/strategies.md
       - Feeds: core_concepts/feeds.md
       - Brokers: core_concepts/brokers.md
       - Exchanges: core_concepts/exchanges.md
       - Caching: core_concepts/caching.md
-  - Plugins & Extras: plugins_and_extras.md
+  - How-to:
+      - Strategy Cookbook: strategy_guide.md
+      - Web Hooks: webhooks.md
   - Reference:
+      - Entry Points & API Freeze: reference/entry_points.md
       - Web API Reference: reference/web_api.md
       - Configuration Reference: reference/configuration.md
-      - Entry Points & API Freeze: reference/entry_points.md
+  - Testing & Reliability:
+      - Runtime Guarantees: testing/runtime_guarantees.md
+      - Testing Guidelines: development/testing_guidelines.md
+      - Test Coverage Responsibilities: testing/test_coverage.md
+      - Known Gaps: testing/known_gaps.md
+      - Strategy Analysis: testing/strategy_analysis.md
+      - Fixtures & Sample Strategy: testing/fixture_strategy.md
+      - Mocking Policy: testing/mocking_policy.md
+      - Backtrader Compatibility Envelope: testing/backtrader_compatibility_envelope.md
+      - Rust CI Policy: testing/rust_ci_policy.md
+  - Migration and Compatibility:
+      - Legacy Architecture Context: core_concepts/architecture.md
+      - Schema-First Boundary RFC: plans/schema_first_python_rust_boundary_rfc.md
+      - Backtrader Broker API Envelope: compatibility/backtrader_broker_api_envelope.md
+  - Reference Appendices:
+      - Plugins and Extras: plugins_and_extras.md
+  - Performance:
+      - Overview: performance/overview.md
+      - Caching Guide: performance/caching_guide.md
+      - Large Datasets: performance/large_datasets.md
+      - Benchmarking: performance/benchmarking.md
+      - Optimization Roadmap: performance/optimization_roadmap.md
   - Development:
-      - Performance:
-          - Overview: performance/overview.md
-          - Caching Guide: performance/caching_guide.md
-          - Large Datasets: performance/large_datasets.md
-          - Benchmarking: performance/benchmarking.md
-          - Optimization Roadmap: performance/optimization_roadmap.md
-      - Testing & Quality:
-          - Runtime Guarantees: testing/runtime_guarantees.md
-          - Testing Guidelines: development/testing_guidelines.md
-          - Test Coverage Responsibilities: testing/test_coverage.md
-          - Known Gaps: testing/known_gaps.md
-          - Strategy Analysis: testing/strategy_analysis.md
-          - Fixtures & Sample Strategy: testing/fixture_strategy.md
-          - Mocking Policy: testing/mocking_policy.md
-          - Backtrader Compatibility Envelope: testing/backtrader_compatibility_envelope.md
-          - Rust CI Policy: testing/rust_ci_policy.md
-      - Contributing:
-          - Overview: development/README.md
-          - Workflow: development/workflow.md
-          - Quick Reference: development/quick-reference.md
-          - Publishing: development/publishing.md
+      - Overview: development/README.md
+      - Workflow: development/workflow.md
+      - Quick Reference: development/quick-reference.md
+      - Publishing: development/publishing.md
   - Project (internal):
       - Documentation plan: internal/DOCUMENTATION_PLAN.md
       - Documentation status: internal/DOCUMENTATION_STATUS.md


### PR DESCRIPTION
## Summary
- reorganize both MkDocs nav configs around stable runtime boundaries instead of historical section accretion
- add an explicit source-of-truth and migration map so readers can distinguish current architecture truth, migration guidance, legacy context, and appendices
- surface migration and compatibility material as a dedicated docs category rather than leaving that role implicit

## Testing
- `python -m mkdocs build -f mkdocs-subtree.yml --site-dir D:\tmp\mkdocs_site_ia_boundaries`
- `python -m mkdocs build --strict -f mkdocs-subtree.yml` *(still fails on the same pre-existing legacy warnings outside this change)*

## Issue
- closes #4