### PR TITLE
docs: add operator troubleshooting and research-factory workflow guides

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,10 +77,13 @@ nav:
   - How-to:
       - Strategy Cookbook: strategy_guide.md
       - Web Hooks: webhooks.md
+      - Operator Troubleshooting Workflow: support/operator_troubleshooting_workflow.md
+      - On-chain Ops Runbook: support/onchain_ops_runbook.md
   - Reference:
       - Entry Points & API Freeze: reference/entry_points.md
       - Web API Reference: reference/web_api.md
       - Configuration Reference: reference/configuration.md
+      - Research Factory Workflow: reference/research_factory_workflow.md
   - Testing & Reliability:
       - Runtime Guarantees: testing/runtime_guarantees.md
       - Testing Guidelines: development/testing_guidelines.md

--- a/reference/research_factory_workflow.md
+++ b/reference/research_factory_workflow.md
@@ -1,0 +1,135 @@
+# Research Factory Workflow, Capability Taxonomy, and Experiment Families
+
+Source repositories:
+
+- [`cracktrader-lab`](https://github.com/cracktrader/cracktrader-lab)
+- [`cracktrader-research-control`](https://github.com/cracktrader/cracktrader-research-control)
+
+This page explains how Cracktrader research scales from single deterministic
+runs to reusable experiment libraries with explicit capability coverage and
+governance handoff.
+
+Use it with:
+
+- [Research Pipeline](research_pipeline.md)
+- [Research Samplers](research_samplers.md)
+
+## Mental Model
+
+Treat research as a factory, not a sequence of one-off runs:
+
+1. Define a strategy family and capability expectations.
+2. Execute deterministic evaluations and falsification suites.
+3. Aggregate outcomes at cohort/family level.
+4. Seal evidence and hand off promotion decisions to governance surfaces.
+
+## Capability Taxonomy
+
+A capability is an operator/research expectation that a strategy family should
+demonstrate under both baseline and stress conditions.
+
+Recommended capability groups:
+
+- Signal robustness: signal still behaves under noise/regime drift
+- Execution resilience: route/latency/fee changes do not collapse intent quality
+- Inventory stability: unwind/hedge paths remain controlled under stress
+- Cost tolerance: edge survives realistic fee and slippage ranges
+- Governance readiness: evidence quality supports repeatable gate evaluation
+
+Capabilities should be declared at strategy-family level and referenced by
+falsification suites and evaluation plans.
+
+## Falsification Suite Catalog Model
+
+The current `research_governance` model already has reusable suite contracts:
+
+- `FalsificationSuite` (family, suite name, version, metadata)
+- `FalsificationCase` (case id, perturbation set, expected failure modes)
+- `execute_falsification_suite(...)` for deterministic suite execution
+- suite registry (`register_falsification_suite`, `list_registered_suites`)
+
+Catalog guidance:
+
+- keep suites versioned and family-scoped
+- tag each suite/case with target capability areas
+- track expected failure modes explicitly
+- publish suite metadata so coverage can be audited without reading code internals
+
+## Experiment Families and Cohorts
+
+An experiment family is a reusable batch template for a hypothesis, not a single
+run. Cohorts are the concrete variants executed under that family.
+
+Common cohort dimensions:
+
+- baseline vs challenger strategy revisions
+- market cohorts (venue groups, symbol groups, liquidity tiers)
+- parameter cohorts (risk/execution/cost sweeps)
+- regime cohorts (volatility/latency/funding conditions)
+
+Target outcome: deterministic grouped comparisons that are easy to report and
+re-run.
+
+## Reference Workflow
+
+### Step 1: Define family hypothesis and capability targets
+
+For each strategy family, define:
+
+- family id and revision lineage
+- capability targets expected to pass
+- failure modes expected to be falsified
+
+### Step 2: Build deterministic pack inputs
+
+Use `ctlab` strategy-pack artifacts (`strategy.json`, `evaluation.json`) as the
+base declaration of strategy and evaluation intent.
+
+Include:
+
+- split plan and stress settings
+- search lineage metadata
+- candidate handoff metadata
+
+### Step 3: Execute evaluation and falsification cohorts
+
+Run deterministic evaluations and falsification suites for each cohort variant.
+Persist run/report metadata through the run registry and report outputs.
+
+### Step 4: Compare at family and cohort level
+
+Use comparison tooling and run metadata to evaluate:
+
+- baseline vs challenger deltas
+- cohort consistency
+- capability coverage completeness
+
+### Step 5: Seal evidence for governance handoff
+
+Package artifacts/runs into sealed evidence bundles and hand off to
+`cracktrader-research-control` for stage-gate and rollout-state reasoning.
+
+In the current lab flow, this starts from the candidate-pack boundary
+(`ctlab candidate pack <slug>`) and continues through evidence sealing and gate
+evaluation on the control-plane side.
+
+This keeps policy evaluation deterministic while preserving control-plane
+ownership of promotion truth.
+
+## Current State vs Target Expansion
+
+Current implemented building blocks:
+
+- deterministic strategy-pack based run flow (`ctlab`)
+- run registry and report pipeline
+- deterministic falsification suite contracts and registry
+- sealed evidence and promotion-state primitives in research-control
+
+Target expansion tracked by active issues:
+
+- richer falsification suite catalog and strategy capability declarations
+- experiment-family templates and cohort orchestration primitives
+- clearer discovery/reporting for capability and suite coverage
+
+These extensions should remain deterministic and composable with existing run
+registry and governance handoff contracts.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocstrings==0.26.1
 mkdocstrings-python==1.12.1
 mkdocs-autorefs==1.2.0
 pymdown-extensions==10.11
+pygments<2.20

--- a/support/operator_troubleshooting_workflow.md
+++ b/support/operator_troubleshooting_workflow.md
@@ -1,0 +1,155 @@
+# Operator Troubleshooting and SLO Investigation Workflow
+
+This guide defines the standard operator loop for investigating unhealthy
+runtimes, rollout regressions, and stale evidence in the current Cracktrader
+platform.
+
+Use it with:
+
+- [Web API Reference](../reference/web_api.md)
+- [Runtime Map](../architecture/runtime_map.md)
+- [On-chain Ops Runbook](onchain_ops_runbook.md)
+
+## What This Workflow Answers
+
+During an incident, answer these questions in order:
+
+1. What is unhealthy right now?
+2. What changed recently?
+3. Is this a rollout regression, stale input/evidence problem, or runtime fault?
+4. What evidence should be inspected next?
+
+The sections below map each question to concrete UI and API surfaces.
+
+## Primary Operator Surfaces
+
+### UI surfaces (current)
+
+- Fleet overview: first-pass health, kill-switch state, and attention queue
+- Runtime detail:
+  - `Overview`: lifecycle and top-level runtime posture
+  - `Routes`: venue/route health and execution-path degradation
+  - `Events`: event chronology for change detection
+  - `Portfolio` and `Risk`: impact and policy posture
+  - `Reports`: latest completed run/report context
+
+### Backend/read-model surfaces (current)
+
+From `cracktrader` Web API:
+
+- `GET /api/v1/health`
+- `GET /api/v1/status`
+- `GET /api/v1/status/detailed`
+- `GET /api/v1/results`
+- `WS /api/v1/ws/status`
+
+From `cracktrader-research-control`:
+
+- `GET /promotion-state/{subject_type}/{subject_id}`
+- `GET /rollout-state/{deployable_version_id}`
+
+### Planned incident/readiness surfaces
+
+The operator epic (`cracktrader-org#35`) is tracking higher-level incident
+summaries for:
+
+- rollout regression timelines
+- stale evidence windows
+- readiness/SLO summaries per runtime and deployable
+
+Until those land, use the correlation workflow below.
+
+## SLO-First Triage Loop
+
+Treat every incident as an SLO investigation instead of a generic debug session.
+
+### Step 1: Confirm blast radius and urgency
+
+Check:
+
+- fleet attention queue in UI
+- `GET /api/v1/health` for service-level checks
+- `GET /api/v1/status` for active runtime posture
+
+Record:
+
+- affected runtime IDs
+- first-observed timestamp
+- current severity (`degraded`, `kill_switch`, or hard failure)
+
+### Step 2: Build a change timeline
+
+Use:
+
+- runtime `Events` tab in UI
+- websocket status stream (`WS /api/v1/ws/status`)
+- runtime `status/detailed` payload snapshots
+
+Goal:
+
+- identify the first event that materially changed runtime behavior
+- separate persistent failure from transient spikes
+
+### Step 3: Classify failure mode
+
+Use this decision split:
+
+- Rollout regression:
+  runtime degraded after a deployable/stage transition or rollout event
+- Stale evidence/input:
+  runtime appears live but evidence/read-model freshness is behind expectations
+- Runtime fault:
+  runtime health drops independent of rollout changes (route faults, venue issues,
+  policy trips, infra faults)
+
+For rollout-linked incidents, inspect control-plane state directly:
+
+- `GET /rollout-state/{deployable_version_id}`
+- `GET /promotion-state/{subject_type}/{subject_id}`
+
+### Step 4: Inspect next evidence layer
+
+Pick evidence based on classification:
+
+- Rollout regression:
+  rollout-state transitions, promotion verdict context, recent runtime events
+- Stale evidence/input:
+  latest evidence timestamps, missing bundle updates, stream lag indicators
+- Runtime fault:
+  route-level health, risk posture, execution/report anomalies
+
+If on-chain routes are involved, run the on-chain checklist from
+[On-chain Ops Runbook](onchain_ops_runbook.md).
+
+### Step 5: Decide and record operator action
+
+Use runtime controls only after classification:
+
+- `pause` when behavior is uncertain and containment is needed
+- `resume` when checks pass and evidence is current
+- `kill` when active risk or policy breach is confirmed
+
+Every incident note should include:
+
+- affected runtime/deployable identifiers
+- classification (`rollout_regression`, `stale_evidence`, `runtime_fault`)
+- primary triggering event
+- evidence inspected
+- operator action and timestamp
+
+## Investigation Matrix
+
+| Question | UI first stop | Backend confirmation | Typical next action |
+| --- | --- | --- | --- |
+| What is unhealthy right now? | Fleet overview | `/api/v1/health`, `/api/v1/status` | Scope affected runtimes and severity |
+| What changed recently? | Runtime `Events` tab | `/api/v1/status/detailed`, websocket status stream | Build incident timeline |
+| Is this rollout-linked? | Runtime `Overview` and `Events` | `/rollout-state/...`, `/promotion-state/...` | Confirm stage transition vs runtime-only fault |
+| Is evidence stale? | Runtime `Reports` and event cadence | promotion/rollout state recency, latest results | Hold rollout or pause runtime pending fresh evidence |
+| What should I do now? | Runtime action controls | confirm classification + risk state | pause/resume/kill with incident record |
+
+## Operational Notes
+
+- Keep incident narratives SLO-oriented. Avoid ad hoc logs-first investigations.
+- Prefer immutable event/state reads before intervention.
+- When uncertain between stale-evidence and runtime-fault classes, contain first
+  (`pause`) and continue evidence collection.


### PR DESCRIPTION
## Summary
- add an operator troubleshooting and SLO-oriented investigation workflow guide
- add a dedicated research-factory workflow reference with capability taxonomy and experiment-family framing
- wire both into MkDocs navigation so they are discoverable

## Issues
- Closes #15
- Closes #16

## Notes
- `mkdocs` was not available in the local environment, so docs build validation was not run locally.