### PR TITLE
fix(docs): make the canonical documentation build strict-clean

### DIFF
--- a/advanced/web_api.md
+++ b/advanced/web_api.md
@@ -1114,6 +1114,6 @@ if __name__ == "__main__":
 ---
 
 **Next Steps:**
-- [Broker Integration](brokers.md) - Order execution and management
-- [Advanced Configuration](advanced.md) - Performance tuning and scaling
-- [Extending Cracktrader](extending.md) - Building custom integrations
+- [Broker Integration](../core_concepts/brokers.md) - Order execution and management
+- [Advanced Configuration](../getting_started/configuration.md) - Performance tuning and scaling
+- [Extending Cracktrader](../development/README.md) - Building custom integrations

--- a/core_concepts/feeds.md
+++ b/core_concepts/feeds.md
@@ -848,5 +848,5 @@ feed = CleanedDataFeed(store=store, symbol='BTC/USDT', timeframe='1h')
 
 **Next Steps:**
 - [Broker Integration](brokers.md) - Order execution and management
-- [Strategy Development](strategy_guide.md) - Using data feeds in strategies
-- [Advanced Configuration](advanced.md) - Performance tuning and optimization
+- [Strategy Development](../strategy_guide.md) - Using data feeds in strategies
+- [Advanced Configuration](../performance/overview.md) - Performance tuning and optimization

--- a/examples/basic_strategy.md
+++ b/examples/basic_strategy.md
@@ -38,7 +38,7 @@ def next(self):
 
 ## Next Steps
 
-- [Multi-Asset Strategy](multi_asset.md) - Trade multiple symbols
-- [Live Trading](live_trading.md) - Deploy to production
-- [Web Dashboard](web_dashboard.md) - Monitor with web interface
+- [Multi-Asset Strategy](../tutorials/multi_asset.md) - Trade multiple symbols
+- [Live Trading](../getting_started/configuration.md) - Deploy to production
+- [Web Dashboard](../getting_started/web_interface.md) - Monitor with web interface
 - [Performance Guide](../performance/overview.md) - Optimize for speed

--- a/mkdocs-subtree.yml
+++ b/mkdocs-subtree.yml
@@ -8,6 +8,7 @@ edit_uri: ""  # Disable edit links for private repo
 # Docs directory - in subtree, markdown files are at root level
 docs_dir: .
 site_dir: /tmp/mkdocs_site
+exclude_docs: /README.md
 
 theme:
   name: material


### PR DESCRIPTION
## What changed
- excludes only the repository-root README from the MkDocs source tree
- repairs invalid links in advanced API, feed, and basic-strategy documentation

## Why
The strict MkDocs build failed on link warnings and the root README/index conflict, preventing docs from participating in the workspace merge gate.

## Impact
The production subtree configuration now builds successfully in strict mode without hiding nested README pages.

## Validation
- strict MkDocs subtree build passed
- full workspace documentation verification passed