### PR TITLE
docs: replace stale status with current cleanup backlog

### DIFF
--- a/internal/DOCUMENTATION_STATUS.md
+++ b/internal/DOCUMENTATION_STATUS.md
@@ -1,103 +1,37 @@
-# Documentation Status
+# Documentation status
 
-## ✅ Completed
+This file tracks structural cleanup, not product claims. For current technical truth, follow the
+precedence in `migration/docs_source_of_truth.md`.
 
-### **Performance Section** (Major Addition)
-- `performance/overview.md` - Performance philosophy and baseline metrics
-- `performance/benchmarking.md` - How to use bench.py tool
-- `performance/large_datasets.md` - Analysis of large dataset challenges (copied from performance/)
-- `performance/optimization_roadmap.md` - Rust/Go optimization plans (copied from performance/)
-- `performance/caching_guide.md` - Detailed guide to HistoricalDataCache
+## Current state
 
-### Core Concepts Enhancement
-- `core_concepts/caching.md` - Overview of data caching system
+- The canonical MkDocs build is strict-clean on the `codex/docs-strict-build` branch/PR #24.
+- `architecture/` owns the current runtime and service map.
+- `testing/` plus `development/testing_guidelines.md` own reliability guarantees.
+- `reference/` owns stable user-facing contracts.
+- `migration/` and `compatibility/` explain staged transitions.
+- `plans/` and `internal/` are non-canonical implementation history and handoff material.
 
-### **Getting Started**
-- `getting_started/quickstart.md` - 5-minute setup guide
-- Updated `index.md` with more direct, internal-focused tone
-- Updated `mkdocs.yml` navigation to include performance section
+## Cleanup backlog
 
-### **Documentation Infrastructure**
-- Documentation builds successfully with new structure
-- Performance insights now prominently featured
-- Internal tone (no marketing fluff) established
+1. `advanced/web_api.md` (~1,119 lines) and `reference/web_api.md` overlap. Keep conceptual/operator
+   guidance in `advanced/`; keep endpoints, payloads, and authentication contracts in `reference/`.
+   Replace duplicated sections with links and add a strict-build link check.
+2. `strategy_guide.md` (~964 lines) should become an index plus focused pages under `tutorials/` and
+   `reference/`. Move one topic per PR and retain redirects/links for existing anchors.
+3. `core_concepts/feeds.md` (~852 lines) mixes concepts, adapter details, and recipes. Split current
+   concepts from venue-specific reference and tutorials without changing runtime semantics.
+4. The large architecture/refactor plans are historical inputs, not current truth. Add front matter
+   or an opening status block naming the date, implementation state, and canonical replacement.
+5. Consolidate the root `getting_started.md` overview with the `getting_started/` index while
+   preserving the navigation entry and external links.
+6. Audit quantitative performance/exchange-count claims against reproducible evidence before
+   publishing them. Remove or qualify claims that lack a versioned source.
 
-## ⚠️ Missing Files (Referenced in Navigation)
+## Acceptance for content moves
 
-### **Getting Started**
-- `getting_started/configuration.md` - Config.json setup, environment variables
-- `getting_started/first_strategy.md` - Step-by-step strategy tutorial
-
-### **Core Concepts**
-- `core_concepts/exchanges.md` - 100+ exchanges, how to add new ones
-- `core_concepts/feeds.md` - Working with data feeds (should move existing feeds.md)
-- `core_concepts/brokers.md` - Live/back/paper broker modes
-- `core_concepts/strategies.md` - Strategy development patterns
-
-### **Advanced**
-- `advanced/live_trading.md` - Production deployment
-- `advanced/backtesting.md` - Optimization, large datasets
-- `advanced/testing.md` - Should move existing testing.md
-- `advanced/monitoring.md` - Health checks, logging
-- `advanced/web_api.md` - Should move existing gui.md
-
-### **Examples**
-- `examples/basic_strategy.md` - Tutorial-style examples
-- `examples/multi_asset.md` - Portfolio strategies
-- `examples/live_trading.md` - Production setup
-- `examples/web_dashboard.md` - Using React frontend
-
-### **API Reference**
-- `reference/store.md` - Auto-generated from docstrings
-- `reference/broker.md` - Auto-generated
-- `reference/feeds.md` - Auto-generated
-- `reference/utils.md` - Auto-generated
-
-## 📋 Next Steps
-
-### **Priority 1: Fix Navigation Errors** (30 minutes)
-1. Move existing files to correct locations:
-   - `feeds.md` → `core_concepts/feeds.md`
-   - `gui.md` → `advanced/web_api.md`
-   - `testing.md` → `advanced/testing.md`
-
-2. Create minimal placeholder files for missing navigation items
-
-### **Priority 2: Essential Content** (2 hours)
-1. `getting_started/configuration.md` - Critical for setup
-2. `getting_started/first_strategy.md` - Step-by-step tutorial
-3. `core_concepts/brokers.md` - Explain live/back/paper modes
-4. `examples/basic_strategy.md` - Runnable example with explanation
-
-### **Priority 3: Advanced Topics** (4 hours)
-1. Complete API reference with auto-generation
-2. Advanced topics (live trading, monitoring)
-3. More comprehensive examples
-4. Cross-references between sections
-
-## 🎯 Key Achievements
-
-1. **Performance transparency**: Comprehensive benchmarking and optimization documentation
-2. **Caching discovery**: Documented the existing HistoricalDataCache system (major value add)
-3. **Internal tone**: Removed marketing language, focused on practical information
-4. **Structured navigation**: Clear hierarchy from basic to advanced topics
-5. **Working build**: Documentation compiles successfully
-
-## 💡 Unique Value Props Documented
-
-1. **Performance benchmarking**: bench.py tool with detailed profiling
-2. **Historical data caching**: 90-99% performance improvement for backtesting
-3. **Large dataset handling**: 5M+ candle strategies with memory management
-4. **Production monitoring**: Health checks and structured logging
-5. **Multi-exchange architecture**: 400+ exchanges with unified API
-
-## Current State
-
-- **Navigation structure**: ✅ Complete and logical
-- **Key content**: ✅ Performance section fully documented
-- **Build system**: ✅ Working MkDocs setup
-- **Tone**: ✅ Internal-focused, no marketing fluff
-- **Missing files**: ⚠️ 18 placeholder files needed
-- **Cross-references**: ⚠️ Many broken links need fixing
-
-**Estimated completion time**: 6-8 hours for full documentation coverage.
+- `python -m mkdocs build --strict --config-file mkdocs-subtree.yml` passes.
+- No duplicate canonical explanation is introduced.
+- Old links are preserved or replaced with explicit redirects.
+- Code/config examples are validated against the pinned workspace, not copied from historical
+  plans.


### PR DESCRIPTION
## Outcome

Replaces a stale, mojibake-corrupted documentation status page that still claimed existing files were missing and advertised unverified product metrics.

## Dependency

Stacked on #24 (strict-clean canonical build).

## New handoff

The status page now:

- points readers to the explicit source-of-truth precedence
- records the actual architecture/testing/reference/migration ownership
- defines six bounded content cleanup slices for duplicate Web API docs, the strategy guide, feed concepts, historical plans, getting-started duplication, and unproven quantitative claims
- gives exact acceptance criteria for link preservation and strict builds

## Validation

`python -m mkdocs build --strict --config-file mkdocs-subtree.yml` completed successfully. MkDocs still reports the existing intentionally unnav'd pages and one pre-existing examples-directory link; those are now explicit backlog inputs rather than falsely described as missing content.
